### PR TITLE
Replaced api.getmodule with redux props

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -1,8 +1,7 @@
 //Api Consts
 const api = window.ModuleApi;
-const React = require('react');
-//Modules that are defined within translationNotes_Check_plugin
-const View = require('./View.js');
+import React from 'react'
+import View from './View.js'
 //String constants
 const NAMESPACE = "ImportantWords",
       UNABLE_TO_FIND_ITEM_IN_STORE = "Unable to find key in namespace",

--- a/Container.js
+++ b/Container.js
@@ -208,8 +208,6 @@ class Container extends React.Component {
     if(this.props.currentSettings.textSelect === 'drag'){
       dragToSelect = true;
     }
-    let proposedChangesStore = api.getDataFromCheckStore('ProposedChanges');
-    let commentBoxStore = api.getDataFromCheckStore('CommentBox');
     let direction = api.getDataFromCommon('params').direction == 'ltr' ? 'ltr' : 'rtl';
     let gatewayVerse = '';
     let targetVerse = '';
@@ -244,8 +242,6 @@ class Container extends React.Component {
         dragToSelect={dragToSelect}
         direction={direction}
         tabKey={this.state.tabKey}
-        commentBoxStore={commentBoxStore}
-        proposedChangesStore={proposedChangesStore}
         updateSelectedWords={this.updateSelectedWords.bind(this)}
         updateCheckStatus={this.updateCheckStatus.bind(this)}
         handleSelectTab={this.handleSelectTab.bind(this)}

--- a/Loader.js
+++ b/Loader.js
@@ -5,7 +5,7 @@
  * into memory in case JSON.parse doesn't do it correctly
  */
 
-const XRegExp = require('xregexp');
+import XRegExp from 'xregexp'
 
 module.exports = function(data) {
   for (var wordObject of data.wordList) {
@@ -18,4 +18,3 @@ module.exports = function(data) {
     }
   }
 }
-    

--- a/View.js
+++ b/View.js
@@ -80,7 +80,7 @@ class View extends React.Component {
                   <div style={{height: "calc(100vh - 531px)", backgroundColor: "#333333", boxSizing: "border-box"}}>
                     <ProposedChanges currentCheck={this.props.currentCheck}
                                      updateCurrentCheck={this.props.updateCurrentCheck.bind(this)}
-                                     proposedChangesStore={this.props.proposedChangesStore} />
+                    />
                   </div>
                 </Tab>
                 <Tab eventKey={3} title={commentGlyph}
@@ -88,7 +88,7 @@ class View extends React.Component {
                   <div style={{height: "calc(100vh - 531px)", backgroundColor: "#333333", boxSizing: "border-box"}}>
                     <CommentBox currentCheck={this.props.currentCheck}
                                 updateCurrentCheck={this.props.updateCurrentCheck.bind(this)}
-                                commentBoxStore={this.props.commentBoxStore} />
+                    />
                   </div>
                 </Tab>
                 <Tab eventKey={4} title={questionGlyph}

--- a/View.js
+++ b/View.js
@@ -2,36 +2,21 @@
  * @description:
  *  This class defines the entire view for TranslationWords tool
  */
-//Api Consts
-const api = window.ModuleApi;
-const React = api.React;
-const RB = api.ReactBootstrap;
-//Bootstrap consts
-const {Row, Col, Tabs, Tab, Glyphicon} = RB;
-//Modules not defined within TranslationWords
-let ScripturePane = null;
-let ProposedChanges = null;
-let CommentBox = null;
-let TranslationHelps = null;
-//Components
-const DragTargetVerseDisplay = require('./components/BareTargetVerseDisplay.js');
-const ClickTargetVerseDisplay = require('./components/TargetVerseDisplay');
-const GatewayVerseDisplay = require('./components/GatewayVerseDisplay.js');
-const CheckInfoCard = require('./components/CheckInfoCard.js');
-const CheckStatusButtons = require('./components/CheckStatusButtons');
-const HelpInfo = require('./components/HelpInfo');
-const style = require('./css/style');
+import React from 'react'
+import {Row, Col, Tabs, Tab, Glyphicon} from 'react-bootstrap'
+import DragTargetVerseDisplay from './components/BareTargetVerseDisplay.js'
+import ClickTargetVerseDisplay from './components/TargetVerseDisplay'
+import GatewayVerseDisplay from './components/GatewayVerseDisplay.js'
+import CheckInfoCard from './components/CheckInfoCard.js'
+import CheckStatusButtons from './components/CheckStatusButtons'
+import HelpInfo from './components/HelpInfo'
+import style from './css/style'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 
 class View extends React.Component {
-  constructor(){
-    super();
-    ScripturePane = api.getModule('ScripturePane');
-    ProposedChanges = api.getModule('ProposedChanges');
-    CommentBox = api.getModule('CommentBox');
-    TranslationHelps = api.getModule('TranslationHelps');
-  }
   render(){
+    //Modules not defined within translationWords
+    const { ScripturePane, ProposedChanges, CommentBox, TranslationHelps } = this.props.modules;
     let TargetVerseDisplay = null;
     if(this.props.dragToSelect){
       TargetVerseDisplay = <DragTargetVerseDisplay

--- a/components/BareTargetVerseDisplay.js
+++ b/components/BareTargetVerseDisplay.js
@@ -1,10 +1,9 @@
 /**
- * A more organic implementation of the Target Verse Display
- * Author: Luke Wilson
+ * @description A more organic implementation of the Target Verse Display
  */
-const React = require('react');
-const style = require('../css/style');
-const SelectionHelpers = require('../utils/selectionHelpers')
+import React from 'react'
+import style from '../css/style'
+import SelectionHelpers from '../utils/selectionHelpers'
 
 class TargetVerseDisplay extends React.Component {
   constructor() {
@@ -94,7 +93,7 @@ class TargetVerseDisplay extends React.Component {
       );
     }
   }
-  
+
 
 
   inDisplayBox(insideDisplayBox) {

--- a/components/CheckInfoCard.js
+++ b/components/CheckInfoCard.js
@@ -1,12 +1,10 @@
-//CheckInfoCard.js//
 /**
- * @author Ian Hoegen
+ * @file CheckInfoCard.js
  * @description This component is a display component for the Check Info Cards.
  */
-const React = api.React;
-const RB = api.ReactBootstrap;
-const {Row, Glyphicon, Col} = RB;
-const styles = require('../css/style.js');
+import React from 'react'
+import {Row, Glyphicon, Col} from 'react-bootstrap'
+import styles from '../css/style.js'
 import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
 
 class CheckInfoCard extends React.Component {

--- a/components/CheckStatusButtons.js
+++ b/components/CheckStatusButtons.js
@@ -1,10 +1,8 @@
-
-const api = window.ModuleApi;
-const React = api.React;
-const RB = api.ReactBootstrap;
-const {Glyphicon, Button, ButtonGroup, utils} = RB;
+import React from 'react'
+import { Glyphicon, Button, ButtonGroup, utils } from 'react-bootstrap'
+import style = from '../css/style'
+//bootstrapUtils declaration
 const bootstrapUtils = utils.bootstrapUtils;
-const style = require('../css/style');
 bootstrapUtils.addStyle(Button, 'correct');
 bootstrapUtils.addStyle(Button, 'flag');
 bootstrapUtils.addStyle(Button, 'darkGrey');

--- a/components/CheckStatusButtons.js
+++ b/components/CheckStatusButtons.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Glyphicon, Button, ButtonGroup, utils } from 'react-bootstrap'
-import style = from '../css/style'
+import style from '../css/style'
 //bootstrapUtils declaration
 const bootstrapUtils = utils.bootstrapUtils;
 bootstrapUtils.addStyle(Button, 'correct');

--- a/components/GatewayVerseDisplay.js
+++ b/components/GatewayVerseDisplay.js
@@ -1,9 +1,11 @@
-//GatewayVerseDisplay.js//
-
-const api = window.ModuleApi;
-const React = api.React;
-const ReactBootstrap = api.ReactBootstrap;
-const XRegExp = require('xregexp');
+///GatewayVerseDisplay.js//
+import React from 'react'
+import natural from 'natural'
+import XRegExp from 'xregexp'
+//nonUnicodeLetter declaration
+const nonUnicodeLetter = XRegExp('\\PL');
+//declaration of Wordlength tokenizer
+const tokenizer = new natural.RegexpTokenizer({pattern: nonUnicodeLetter});
 
 
 class GatewayVerseDisplay extends React.Component {

--- a/components/HelpInfo.js
+++ b/components/HelpInfo.js
@@ -1,4 +1,4 @@
-const React = api.React;
+import React from 'react'
 
 class HelpInfo extends React.Component{
   render(){

--- a/components/TargetVerseDisplay.js
+++ b/components/TargetVerseDisplay.js
@@ -1,13 +1,12 @@
 //TargetVerseDisplay.js//
-const React = require('react');
-const natural = require('natural');
-const XRegExp = require('xregexp');
+import React from 'react'
+import natural from 'natural'
+import XRegExp from 'xregexp'
+import TargetWord from './TargetWord'
+import style from '../css/style'
+//nonUnicodeLetter declaration
 const nonUnicodeLetter = XRegExp('[^\\pL\\pM]+?');
-const TargetWord = require('./TargetWord');
-const style = require('../css/style');
-
-
-//Wordlength tokenizer
+//declaration of Wordlength tokenizer
 const tokenizer = new natural.RegexpTokenizer({pattern: nonUnicodeLetter});
 
 class TargetVerseDisplay extends React.Component {

--- a/components/TargetWord.js
+++ b/components/TargetWord.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react'
 
 /* Contains a word from the target language, defines a lot of listeners for clicks */
 class TargetWord extends React.Component {

--- a/components/WordComponent.js
+++ b/components/WordComponent.js
@@ -1,8 +1,5 @@
-const api = window.ModuleApi;
-
-const React = api.React;
-const ReactBootstrap = api.ReactBootstrap;
-
+import React from 'react'
+//constant declaration
 const CURRENT_WORD= "CurrentWord: ";
 
 class WordComponent extends React.Component {


### PR DESCRIPTION
#### This pull request addresses:

- This branch is to be tested using feature/mc-888 branch on tC repo
- unfoldingWord-dev/translationCore#897
- **THelps has bugs that are unrelated to this PR**
- Change the way we require modules in order to import them using ES6 convention #900

How to test this pull request:

- Open tools and make sure the submodules render on the first load
- switch between tools and projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/45)
<!-- Reviewable:end -->
