### PR TITLE
added comments to explain weird empty div for scripturePane

### DIFF
--- a/View.js
+++ b/View.js
@@ -18,7 +18,9 @@ class View extends React.Component {
       TranslationHelps
     } = this.props.modules;
 
+    // set the scripturePane to empty to handle react/redux when it first renders without required data
     let scripturePane = <div></div>
+    // pupulate scripturePane so that when required data is preset that it renders as intended.
     if (this.props.modulesSettingsReducer.ScripturePane !== undefined) {
       scripturePane = <ScripturePane {...this.props} currentCheck={this.props.checkStoreReducer.currentCheck} />
     }


### PR DESCRIPTION
updated comments for why scripture pane is empty div at first

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/55)
<!-- Reviewable:end -->
