### PR TITLE
Implement data persistence for module settings reducer

### DIFF
--- a/FetchData/ScripturePane.js
+++ b/FetchData/ScripturePane.js
@@ -25,16 +25,21 @@ var missingChunks = 0;
  * @param {object} actions - The functions that a tool has access to in order to store data
  * after it is loaded
  * @param {function} progress - Function to send to fetch data container to show progress
+ * @param {boolean} scripturePaneSettings - its true if the scripture pane was preloaded
+ * from the file system otherwise its false.
  * @returns {Promise} - Function that gets called when all the data is finished loading
  */
-export default function fetchData(projectDetails, bibles, actions, progress) {
+export default function fetchData(projectDetails, bibles, actions, progress, scripturePaneSettings) {
   return new Promise(function (resolve, reject) {
     const params = projectDetails.params;
     const tcManifest = projectDetails.manifest;
-    const { addNewBible, addNewResource, setModuleSettings } = actions;
-    const { currentPaneSettings, staticPaneSettings } = getPaneSettings(tcManifest);
-    setModuleSettings(NAMESPACE, 'currentPaneSettings', currentPaneSettings);
-    setModuleSettings(NAMESPACE, 'staticPaneSettings', staticPaneSettings);
+    const { addNewBible, setModuleSettings } = actions;
+    // Only generate ScripturePane settings if they were not previously generated and/or loaded from the filesystem.
+    if (!scripturePaneSettings) {
+      const { currentPaneSettings, staticPaneSettings } = getPaneSettings(tcManifest);
+      setModuleSettings(NAMESPACE, 'currentPaneSettings', currentPaneSettings);
+      setModuleSettings(NAMESPACE, 'staticPaneSettings', staticPaneSettings);
+    }
     getTargetLanguage().then(() => {
       progress(33);
       getOriginalLanguage();

--- a/FetchData/main.js
+++ b/FetchData/main.js
@@ -8,9 +8,10 @@ export default function fetchAllData(props) {
   const bibles = props.resourcesReducer.bibles;
   const actions = props.actions;
   const totalProgress = actions.progress;
+  const scripturePaneSettings = props.modulesSettingsReducer.ScripturePane ? true : false;
 
   return new Promise(function(resolve, reject) {
-    scripturePaneData(projectDetails, bibles, actions, progress)
+    scripturePaneData(projectDetails, bibles, actions, progress, scripturePaneSettings)
     .then(()=>{
       FETCH_DATAS_FINISHED++;
       tWFetchData(projectDetails, bibles, actions, progress);


### PR DESCRIPTION
#### This pull request addresses:

This PR recovers data persistence for the scripture pane settings.

#### How to test this pull request:
Test with https://github.com/unfoldingWord-dev/translationCore/pull/1046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/64)
<!-- Reviewable:end -->
