### PR TITLE
Only add checks in filter if they didn't already exist

### DIFF
--- a/FetchData/TranslationWords.js
+++ b/FetchData/TranslationWords.js
@@ -11,7 +11,7 @@ const natural = require('natural');
 const tokenizer = new natural.RegexpTokenizer({ pattern: new XRegExp('\\PL') });
 const fs = require('fs');
 const path = require('path-extra');
-
+import isEqual from 'lodash/isEqual'
 // User imports
 const Door43DataFetcher = require('../js/Door43DataFetcher.js');
 const TranslationWordsFetcher = require('../translation_words/TranslationWordsFetcher.js');
@@ -427,42 +427,42 @@ function getFilters(bookName) {
 function addChecks(checkObj, filters, wordList, params) {
   if (!filters) return null;
   for (var word in filters) {
-    var wordInfo = null;
-    for (var i = 0; i < wordList.length; i++) {
-      if (wordList[i].name === (word + '.txt')) {
-        wordInfo = wordList[i].file;
-        break;
-      }
-    }
     var prevVerses = [];
     while (filters[word].length > 0) {
-      var currentIntstance = filters[word].pop();
+      var currentInstance = filters[word].pop();
       if (!checkObj[word]) checkObj[word] = [];
-      var cv = currentIntstance[2] + ':' + currentIntstance[3];
+      var cv = currentInstance[2] + ':' + currentInstance[3];
       if (prevVerses[cv]) {
         prevVerses[cv]++;
       } else {
         prevVerses[cv] = 1;
       }
-      checkObj[word].push({
+      let check = {
         contextId: {
           groupId: word,
           occurrence: prevVerses[cv],
-          quote: currentIntstance[4],
+          quote: currentInstance[4],
           reference: {
             bookId: params.bookAbbr,
-            chapter: parseInt(currentIntstance[2], 10),
-            verse: parseInt(currentIntstance[3], 10)
+            chapter: parseInt(currentInstance[2], 10),
+            verse: parseInt(currentInstance[3], 10)
           },
           tool: 'ImportantWords'
         },
-        information: wordInfo,
+        information: undefined,
         priority: 1,
         comments: false,
         reminders: false,
         selections: false,
         verseEdits: false
+      };
+      let checkAlreadyInThere = false;
+      checkObj[word].forEach(_check => {
+        if (isEqual(_check.contextId, check.contextId)) checkAlreadyInThere = true;
       });
+      if (!checkAlreadyInThere) {
+        checkObj[word].push(check);
+      }
     }
   }
 }


### PR DESCRIPTION
## This PR Addresses:
Duplicate checks in menu/groupData due to filter having a new entry for an existing check.

## To Test:
Ephesians, tW, Adoption, 1:6, should only have one entry now where it did have two.

IMPORTANT: Test this separately and after tC branch feature/klappy-1117, as that one needs the problem to still exist so that the menu shows the duplicate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/73)
<!-- Reviewable:end -->
