### PR TITLE
updates to flex layout for thelps

### DIFF
--- a/View.js
+++ b/View.js
@@ -3,7 +3,7 @@
  *  This class defines the entire view for TranslationWords tool
  */
 import React from 'react';
-import {Row, Col, Tabs, Tab, Glyphicon} from 'react-bootstrap';
+import {Glyphicon} from 'react-bootstrap';
 import CheckInfoCard from './components/CheckInfoCard.js';
 import style from './css/style';
 
@@ -26,7 +26,7 @@ class View extends React.Component {
 
     return (
         <div style={{display: 'flex', flex: 'auto'}}>
-          <div style={{flex: 3, display: "flex", flexDirection: "column"}}>
+          <div style={{flex: '2 1 1000px', display: "flex", flexDirection: "column"}}>
             {scripturePane}
             <CheckInfoCard openHelps={this.props.toggleHelps} showHelps={this.props.showHelps} title={this.props.contextIdReducer.contextId.quote} file={this.props.currentFile}/>
             <VerseCheck
@@ -35,15 +35,15 @@ class View extends React.Component {
               goToPrevious={this.props.goToPrevious}
             />
           </div>
-          <div style={{flex: 1}}>
-            <div style={{height: "100vh"}}>
-              <Glyphicon glyph={this.props.showHelps ? "chevron-right" : "chevron-left"}
-                         style={this.props.showHelps ? style.tHelpsOpen : style.tHelpsClosed}
-                         onClick={this.props.toggleHelps} />
-                <div style={{display: this.props.showHelps ? "block" : "none", height: "100vh"}}>
-                  <TranslationHelps {...this.props} currentFile={this.props.currentFile}
-                                  online={this.props.statusBarReducer.online}/>
-                </div>
+          <div style={{flex: this.props.showHelps ? '1 0 375px' : '0 0 30px', display: 'flex', justifyContent: 'flex-end', marginLeft: '-15px'}}>
+            <div style={style.iconDiv}>
+                <Glyphicon glyph={this.props.showHelps ? "chevron-right" : "chevron-left"}
+                           style={style.icon}
+                           onClick={this.props.toggleHelps} />
+            </div>
+            <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1 0 360px' }}>
+                <TranslationHelps currentFile={this.props.currentFile}
+                                  online={this.props.statusBarReducer.online} />
             </div>
           </div>
         </div>

--- a/View.js
+++ b/View.js
@@ -36,9 +36,9 @@ class View extends React.Component {
             />
           </div>
           <div style={{flex: this.props.showHelps ? '1 0 375px' : '0 0 30px', display: 'flex', justifyContent: 'flex-end', marginLeft: '-15px'}}>
-            <div style={style.iconDiv}>
+            <div style={style.handleIconDiv}>
                 <Glyphicon glyph={this.props.showHelps ? "chevron-right" : "chevron-left"}
-                           style={style.icon}
+                           style={style.handleIcon}
                            onClick={this.props.toggleHelps} />
             </div>
             <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1 0 360px' }}>

--- a/css/style.js
+++ b/css/style.js
@@ -1,35 +1,15 @@
 var style = {
-  translationHelpsContent: {
-    overflowY: "scroll",
-    minWidth: "100%",
-    padding: '9px',
-    minHeight: "390px",
-    maxHeight: "390px",
-    backgroundColor: "var(--border-color)"
-  },
-  buttonGlyphicons:{
-    color: "var(--reverse-color)",
-    fontSize: "20px"
-  },
-  tHelpsOpen:{
-    float: "left",
-    marginTop: "50vh",
+  icon:{
     zIndex: "999",
     color: "var(--reverse-color)",
     backgroundColor: "var(--text-color-dark)",
     padding: "10px 0px",
-    marginLeft: "-15px",
     borderRadius: "5px 0px 0px 5px"
   },
-  tHelpsClosed:{
-    float: "right",
-    marginTop: "50vh",
-    zIndex: "999",
-    color: "var(--reverse-color)",
-    backgroundColor: "var(--text-color-dark)",
-    padding: "10px 0px",
-    marginLeft: "-15px",
-    borderRadius: "5px 0px 0px 5px"
+  iconDiv: {
+    flex: '0 0 15px',
+    display: 'flex',
+    alignItems: 'center',
   },
   linkActive: {
     fontWeight: 'bold',

--- a/css/style.js
+++ b/css/style.js
@@ -1,12 +1,12 @@
 var style = {
-  icon:{
+  handleIcon:{
     zIndex: "999",
     color: "var(--reverse-color)",
     backgroundColor: "var(--text-color-dark)",
     padding: "10px 0px",
     borderRadius: "5px 0px 0px 5px"
   },
-  iconDiv: {
+  handleIconDiv: {
     flex: '0 0 15px',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
#### This pull request addresses:

Updated flex layout based on issues found in #1645.  Thelps pane no longer shifts sizes and now check area takes up the space when tHelps is collapsed.  Must pull in all three PR's for it to work (tHelps, Notes and Words)



#### How to test this pull request:

Include testing instructions so that other developers know what to look for, and how to make sure that your feature/bugfix/enhancement really works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/90)
<!-- Reviewable:end -->
