### PR TITLE
fixed bug with wrong prop

### DIFF
--- a/View.js
+++ b/View.js
@@ -45,7 +45,7 @@ class View extends React.Component {
             <TranslationHelps
               {...this.props}
               currentFile={currentFile}
-              online={this.props.statusBarReducer.online}
+              online={this.props.settingsReducer.online}
             />
           </div>
         </div>


### PR DESCRIPTION
#### This pull request addresses:

- online prop was using the old `statusBarReducer` instead of settingsReducer.online

#### How to test this pull request:

- Open tW and it should not render a white screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords_check_plugin/97)
<!-- Reviewable:end -->
